### PR TITLE
old ver4 support

### DIFF
--- a/.travis-init.sh
+++ b/.travis-init.sh
@@ -20,7 +20,7 @@ case $REDMINE_VERSION in
           export MIGRATE_PLUGINS=db:migrate_plugins
           export REDMINE_TARBALL=https://github.com/redmine/redmine/archive/$REDMINE_VERSION.tar.gz
           ;;
-  2.* | 3.*)  export PATH_TO_PLUGINS=./plugins # for redmine 2.x and 3.x
+  2.* | 3.* | 4.*)  export PATH_TO_PLUGINS=./plugins # for redmine 2.x, 3.x and 4.x
           export GENERATE_SECRET=generate_secret_token
           export MIGRATE_PLUGINS=redmine:plugins:migrate
           export REDMINE_TARBALL=https://github.com/redmine/redmine/archive/$REDMINE_VERSION.tar.gz
@@ -64,15 +64,29 @@ run_tests() {
     TRACE=--trace
   fi
 
-  echo "--- test start ------------------------"
-  script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake redmine:plugins:test NAME="$PLUGIN $VERBOSE
-  #--- added for ui test ---
-#  if [[ "$REDMINE_VERSION" =~ ^(3.0|3.1)[\-\.] ]]; then
-#    echo "bypass ui test for redmine 3.0 or 3.1"
-#  else
-    echo "--- UI test start ------------------------"
-    script -e -c "RUBYOPT=-W0 bundle exec rake test TEST=plugins/$PLUGIN/test/ui/**/*_test.rb" $VERBOSE
-#  fi
+#  echo "--- test start ------------------------"
+#  script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake redmine:plugins:test NAME="$PLUGIN $VERBOSE
+
+  echo "--- unit test start ------------------------"
+#  script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake redmine:plugins:test:units NAME="$PLUGIN $VERBOSE
+#   script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake test TEST=plugins/issue_mail_with_attachments/test/unit/*_test.rb"
+   script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake test TEST=plugins/issue_mail_with_attachments/test/unit/mailer_patch_edit_status_test.rb"
+   script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake test TEST=plugins/issue_mail_with_attachments/test/unit/mailer_patch_edit_test.rb"
+   script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake test TEST=plugins/issue_mail_with_attachments/test/unit/mailer_patch_orig_issue_test.rb"
+   script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake test TEST=plugins/issue_mail_with_attachments/test/unit/mailer_patch_orig_journal_test.rb"
+   script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake test TEST=plugins/issue_mail_with_attachments/test/unit/mailer_patch_test.rb"
+   script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake test TEST=plugins/issue_mail_with_attachments/test/unit/mailer_patch_add_test.rb"
+
+  echo "--- function test start ------------------------"
+#  script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake redmine:plugins:test:units NAME="$PLUGIN $VERBOSE
+   script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake test TEST=plugins/issue_mail_with_attachments/test/functional/*_test.rb"
+
+  echo "--- integration test start ------------------------"
+#  script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake redmine:plugins:test:units NAME="$PLUGIN $VERBOSE
+   script -e -c "RUBYOPT=-W0 COVERALL4MYPLUGIN=true bundle exec rake test TEST=plugins/issue_mail_with_attachments/test/integration/*_test.rb"
+
+  echo "--- UI test start ------------------------"
+  script -e -c "RUBYOPT=-W0 xvfb-run bundle exec rake test TEST=plugins/$PLUGIN/test/ui/**/*_test.rb" $VERBOSE
 }
 
 uninstall() {
@@ -93,7 +107,7 @@ run_install() {
   cd $PATH_TO_REDMINE	
   
   #mod ver in gemfile
-  sed -i -e "/public_suffix/d" -e "s/.*selenium.*/  gem \'selenium-webdriver\', \'2\.53\.4\'/" -e "s/.*capybara.*/  gem \'capybara\', \'2\.7\.1\'/" ./Gemfile
+  sed -i -e "/public_suffix/d" ./Gemfile
   cat ./Gemfile
  
   # create a link to the plugin, but avoid recursive link.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,22 @@
 language: ruby
 rvm:
+  - 2.6
+  - 2.5
+  - 2.4
   - 2.3
-  - 2.2
-  - 2.1
-  - 2.0
+
 branches:
   only:
     - master
     - refactoring-testing
+    - ver4support
 env:
-  - REDMINE_VERSION=3.4-stable VERBOSE=yes
-  - REDMINE_VERSION=3.3-stable VERBOSE=yes
-  - REDMINE_VERSION=3.2-stable VERBOSE=yes
-  - REDMINE_VERSION=3.1-stable VERBOSE=yes
-  - REDMINE_VERSION=3.0-stable VERBOSE=yes
+  - REDMINE_VERSION=4.0-stable VERBOSE=yes
+  - REDMINE_VERSION=4.1-stable VERBOSE=yes
+
+addons:
+  firefox: latest-esr
+  chrome: stable
 script:
   - export PLUGIN=issue_mail_with_attachments
   - export WORKSPACE=$(pwd)/workspace
@@ -26,7 +29,18 @@ script:
   - bash -x ./.travis-init.sh -u || exit 1
 
 before_install:
-  - "phantomjs --version"
-  
+# - wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz
+# - mkdir geckodriver
+# - tar -xzf geckodriver-v0.24.0-linux64.tar.gz -C geckodriver
+# - export PATH=$PATH:$PWD/geckodriver
+# - geckodriver --version
+# - export MOZ_HEADLESS=1
+ 
+ - export LATEST_CHROMEDRIVER="$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE)"
+ - curl -L -s -o /tmp/chromedriver.zip "https://chromedriver.storage.googleapis.com/${LATEST_CHROMEDRIVER}/chromedriver_linux64.zip"
+ - mkdir chromedriver
+ - unzip /tmp/chromedriver.zip -d chromedriver
+ - export PATH=$PATH:$PWD/chromedriver
+ - chromedriver --version
 before_script:
-  - phantomjs --webdriver=4444 >/dev/null 2>&1 & 
+

--- a/src/issue_mail_with_attachments/Gemfile
+++ b/src/issue_mail_with_attachments/Gemfile
@@ -3,6 +3,6 @@
 group :test do
 	gem 'coveralls', require: false
 	#gem 'simplecov', "~> 0.9.1", :require => false, :group => :test
-	gem 'public_suffix', '2.0.5'
-	gem 'site_prism', '2.7'
+	gem 'public_suffix', '4.0.5'
+	gem 'site_prism', '3.5'
 end

--- a/src/issue_mail_with_attachments/init.rb
+++ b/src/issue_mail_with_attachments/init.rb
@@ -27,10 +27,10 @@ Redmine::Plugin.register :issue_mail_with_attachments do
   name 'Issue Mail With Attachments plugin'
   author 'team888'
   description 'With this plugin, you can send out newly attached files on issues via usual issue notification mails or dedicated mails as attachments.'
-  version '0.9.0'
+  version '0.9.5'
   url 'http://www.redmine.org/plugins/issue_mail_with_attachments'
   author_url 'https://github.com/team888'
-  requires_redmine :version_or_higher => '3.0'
+  requires_redmine :version_or_higher => '4.0'
 
   settings :default => default_settings, :partial => 'settings/issue_mail_with_attachments_settings'
   
@@ -48,7 +48,7 @@ require "issue_mail_with_attachments/mailer_patch.rb"
 Rails.configuration.to_prepare do
   require_dependency 'mailer'
   # load patch module
-  unless Mailer.included_modules.include? IssueMailWithAttachments::MailerPatch
-    Mailer.send(:include, IssueMailWithAttachments::MailerPatch)
+  unless Mailer.included_modules.include? IssueMailWithAttachments::MailerPatch  # https://bugs.ruby-lang.org/issues/8026
+    Mailer.send(:prepend, IssueMailWithAttachments::MailerPatch)
   end
 end

--- a/src/issue_mail_with_attachments/lib/issue_mail_with_attachments/mailer_patch.rb
+++ b/src/issue_mail_with_attachments/lib/issue_mail_with_attachments/mailer_patch.rb
@@ -1,17 +1,12 @@
 
 module IssueMailWithAttachments
   module MailerPatch
-    def self.included(base)
-      base.send(:include, InstanceMethods)
+#    def self.included(base)
+#      base.send(:prepend, InstanceMethods)
+#
+#    end
 
-      base.class_eval do
-        unloadable
-        alias_method_chain :issue_add, :attachments
-        alias_method_chain :issue_edit, :attachments
-      end
-    end
-
-    module InstanceMethods
+#    module InstanceMethods
 
       #=========================================================
       # helper method to set logger level
@@ -139,13 +134,14 @@ module IssueMailWithAttachments
       #=========================================================
       # monkey patch for issue_add method of Mailer class
       #=========================================================
-      def issue_add_with_attachments(issue, to_users, cc_users)
+      def issue_add(to_users, issue)
         prev_logger_lvl = set_logger_level
         Rails.logger.info "--- def issue_add_with_attachments ------"
+        cc_users = nil
         #------------------------------------------------------------
         # call original method
         #------------------------------------------------------------
-        ml = issue_add_without_attachments(issue, to_users, cc_users)
+        ml = super(to_users, issue)
 
         #------------------------------------------------------------
         # evaluate plugin settings
@@ -196,13 +192,14 @@ module IssueMailWithAttachments
       #=========================================================
       # monkey patch for issue_edit method of Mailer class
       #=========================================================
-      def issue_edit_with_attachments(journal, to_users, cc_users)
+      def issue_edit(to_users, journal)
         prev_logger_lvl = set_logger_level
         Rails.logger.info "--- def issue_edit_with_attachments ------"
+        cc_users = nil
         #------------------------------------------------------------
         # call original method
         #------------------------------------------------------------
-        ml = issue_edit_without_attachments(journal, to_users, cc_users)
+        ml = super(to_users, journal)
         issue = journal.journalized
 
         #------------------------------------------------------------
@@ -258,7 +255,7 @@ module IssueMailWithAttachments
         end
         Rails.logger.level = prev_logger_lvl if prev_logger_lvl
       end
-    end
+#    end
   end
 end
 

--- a/src/issue_mail_with_attachments/test/functional/mailer_patch_issues_controller_test.rb
+++ b/src/issue_mail_with_attachments/test/functional/mailer_patch_issues_controller_test.rb
@@ -17,7 +17,7 @@
 
 require File.expand_path('../../test_helper', __FILE__)
 
-if Redmine::VERSION::MAJOR >= 3 and Redmine::VERSION::MINOR >= 4
+#if Redmine::VERSION::MAJOR >= 3 and Redmine::VERSION::MINOR >= 4
 
   class IssuesControllerTest < Redmine::ControllerTest
     fixtures :projects,
@@ -91,7 +91,7 @@ if Redmine::VERSION::MAJOR >= 3 and Redmine::VERSION::MINOR >= 4
         a = Attachment.new(filename:'101123161450_testfile_1.png')
         atts << a
         issue = Issue.order('id DESC').first
-        assert_sent_with_dedicated_mails num_att_mails:2, issue:issue, atts:atts
+        assert_sent_with_dedicated_mails num_att_mails:2, issue:issue, atts:atts, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
 
         attachment = Attachment.order('id DESC')[1]
         assert_equal issue, attachment.container
@@ -106,93 +106,3 @@ if Redmine::VERSION::MAJOR >= 3 and Redmine::VERSION::MINOR >= 4
     end
 
   end
-else
-  class IssuesControllerTest < ActionController::TestCase   # mod for < redmine 3.4
-    fixtures :projects,
-             :users, :email_addresses, :user_preferences,
-             :roles,
-             :members,
-             :member_roles,
-             :issues,
-             :issue_statuses,
-             :issue_relations,
-             :versions,
-             :trackers,
-             :projects_trackers,
-             :issue_categories,
-             :enabled_modules,
-             :enumerations,
-             :attachments,
-             :workflows,
-             :custom_fields,
-             :custom_values,
-             :custom_fields_projects,
-             :custom_fields_trackers,
-             :time_entries,
-             :journals,
-             :journal_details,
-             :queries,
-             :repositories,
-             :changesets
-
-    include Redmine::I18n
-
-    def setup
-      User.current = nil
-    end
-
-    def test_mailer_patch_post_create_with_attachment
-      ActionMailer::Base.deliveries.clear
-      set_tmp_attachments_directory
-      @request.session[:user_id] = 2
-
-      plugin_settings = plugin_settings_init({
-        :enable_mail_attachments => 'true',
-        :attach_all_to_notification => 'false',
-
-        :mail_subject => IssueMailWithAttPluginInfo::DEFAULT_edit_mail_subject,
-        :mail_subject_wo_status => IssueMailWithAttPluginInfo::DEFAULT_edit_mail_subject_wo_status,
-        :mail_subject_4_attachment => IssueMailWithAttPluginInfo::DEFAULT_edit_mail_subject_4_attachment
-      })
-
-      with_settings( {:notified_events => %w(issue_added),
-        :plugin_issue_mail_with_attachments => plugin_settings
-      }) do
-        assert_difference 'Issue.count' do
-          post :create, #:params => {  # mod for < redmine 3.4
-              :project_id => 1,
-              :issue => {
-                :tracker_id => '1',
-                :subject => 'With attachment' 
-              },  
-              :attachments => {
-                '1' => {
-                  'file' => uploaded_test_file('testfile.txt', 'text/plain'), 'description' => 'test file'},
-                '2' => {
-                  'file' => uploaded_test_file("2010/11/101123161450_testfile_1.png", "image/png"), 'description' => 'png file'} 
-              }
-            #}  # mod for < redmine 3.4
-        end
-        atts = []
-        a = Attachment.new(filename:'testfile.txt')
-        atts << a
-        a = Attachment.new(filename:'101123161450_testfile_1.png')
-        atts << a
-        issue = Issue.order('id DESC').first
-        assert_sent_with_dedicated_mails num_att_mails:2, issue:issue, atts:atts
-
-        attachment = Attachment.order('id DESC')[1]
-        assert_equal issue, attachment.container
-        assert_equal 2, attachment.author_id
-        assert_equal 'testfile.txt', attachment.filename
-        assert_equal 'text/plain', attachment.content_type
-        assert_equal 'test file', attachment.description
-        assert_equal 59, attachment.filesize
-        assert File.exists?(attachment.diskfile)
-        assert_equal 59, File.size(attachment.diskfile)
-      end
-    end
-
-  end
-  
-end

--- a/src/issue_mail_with_attachments/test/test_helper.rb
+++ b/src/issue_mail_with_attachments/test/test_helper.rb
@@ -23,33 +23,40 @@ require File.expand_path(File.dirname(__FILE__) + '/../../../test/test_helper')
     end
   end
   
-  def assert_sent_with_dedicated_mails(num_att_mails:3, atts:nil, issue:nil, attachment:nil, journal:nil, journal_detail:nil, title_wo_status:false)
-    assert_equal num_att_mails +1, ActionMailer::Base.deliveries.size
-    (1..(num_att_mails)).each do |r|
-      m = ActionMailer::Base.deliveries[-r]
-      assert_equal 1, m.attachments.size
-      if atts and issue
-#        p atts[num_att_mails - r].filename
-        assert_equal eval("\"#{Setting.plugin_issue_mail_with_attachments[:mail_subject_4_attachment]}\"") + atts[num_att_mails - r].filename, m.subject
+  def assert_sent_with_dedicated_mails(num_att_mails:3, atts:nil, issue:nil, attachment:nil, journal:nil, journal_detail:nil, title_wo_status:false, recipients:recipients)
+    assert_equal (num_att_mails + 1) * recipients.size, ActionMailer::Base.deliveries.size
+
+    recipients.size.times do |b|
+      off = (b + 1) * (num_att_mails + 1)
+      (1..(num_att_mails)).each do |r|
+        m = ActionMailer::Base.deliveries[off - r]
+        assert_equal [recipients[b]], m.bcc
+        assert_equal 1, m.attachments.size
+        if atts and issue
+          assert_equal eval("\"#{Setting.plugin_issue_mail_with_attachments[:mail_subject_4_attachment]}\"") + atts[num_att_mails - r].filename, m.subject
+        end
+        assert_mail_headers(m, issue)
       end
-      assert_mail_headers(m, issue)
-    end
     
-    m = ActionMailer::Base.deliveries[-(num_att_mails +1)]
-    assert_equal 0, m.attachments.size
-    if issue
-      if title_wo_status
-        assert_equal eval("\"#{Setting.plugin_issue_mail_with_attachments[:mail_subject_wo_status]}\""), m.subject 
-      else
-        assert_equal eval("\"#{Setting.plugin_issue_mail_with_attachments[:mail_subject]}\""), m.subject 
+      m = ActionMailer::Base.deliveries[off - (num_att_mails +1)]
+      assert_equal [recipients[b]], m.bcc
+      assert_equal 0, m.attachments.size
+      if issue
+        if title_wo_status
+          assert_equal eval("\"#{Setting.plugin_issue_mail_with_attachments[:mail_subject_wo_status]}\""), m.subject 
+        else
+          assert_equal eval("\"#{Setting.plugin_issue_mail_with_attachments[:mail_subject]}\""), m.subject 
+        end
       end
     end
   end
   
-  def assert_sent_with_attach_all(atts:nil, issue:nil, attachment:nil, journal:nil, journal_detail:nil, title_wo_status:false)
-      assert_equal 1, ActionMailer::Base.deliveries.size
-      m = ActionMailer::Base.deliveries.last
-      assert_equal 3, m.attachments.size
+  def assert_sent_with_attach_all(atts:nil, issue:nil, attachment:nil, journal:nil, journal_detail:nil, title_wo_status:false, recipients:recipients)
+    assert_equal recipients.size, ActionMailer::Base.deliveries.size
+    recipients.size.times do |b|
+      m = ActionMailer::Base.deliveries[b]
+      assert_equal [recipients[b]], m.bcc
+      assert_equal atts.size, m.attachments.size
       if issue
         if title_wo_status
           assert_equal eval("\"#{Setting.plugin_issue_mail_with_attachments[:mail_subject_wo_status]}\""), m.subject 
@@ -58,11 +65,14 @@ require File.expand_path(File.dirname(__FILE__) + '/../../../test/test_helper')
         end
       end
       assert_mail_headers(m, issue)
+    end
   end
 
-  def assert_sent_with_no_attachments(issue:nil, title_wo_status:false)
-      assert_equal 1, ActionMailer::Base.deliveries.size
-      m = ActionMailer::Base.deliveries.last
+  def assert_sent_with_no_attachments(issue:nil, title_wo_status:false, recipients:recipients)
+    assert_equal recipients.size, ActionMailer::Base.deliveries.size
+    recipients.size.times do |b|
+      m = ActionMailer::Base.deliveries[b]
+      assert_equal [recipients[b]], m.bcc
       assert_equal 0, m.attachments.size
       if issue
         if title_wo_status
@@ -72,6 +82,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../../test/test_helper')
         end
       end
       assert_mail_headers(m, issue)
+    end
   end
   
   def assert_mail_headers(mail, issue)

--- a/src/issue_mail_with_attachments/test/ui/plugin_configuration_test.rb
+++ b/src/issue_mail_with_attachments/test/ui/plugin_configuration_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../../../test/ui/base', __FILE__)
+require File.expand_path('../../../../../test/application_system_test_case', __FILE__)
 require File.expand_path('../../test_helper', __FILE__)
 
 # Page object of list of plugins page
@@ -24,7 +24,9 @@ class IssueMailAttPluginSettingPage < SitePrism::Page
   
 end
 
-class Redmine::UiTest::IssuesTest < Redmine::UiTest::Base
+class IssuesTest < ApplicationSystemTestCase
+#  driven_by :selenium, using: :firefox
+  
   fixtures :projects, :users, :email_addresses, :roles, :members, :member_roles,
            :trackers, :projects_trackers, :enabled_modules, :issue_statuses, :issues,
            :enumerations, :custom_fields, :custom_values, :custom_fields_trackers,

--- a/src/issue_mail_with_attachments/test/unit/mailer_patch_add_test.rb
+++ b/src/issue_mail_with_attachments/test/unit/mailer_patch_add_test.rb
@@ -2,6 +2,8 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class MailPatchAddTest < ActiveSupport::TestCase
+  self.test_order = :sorted
+
   include Redmine::I18n
   include Rails::Dom::Testing::Assertions
 
@@ -19,6 +21,10 @@ class MailPatchAddTest < ActiveSupport::TestCase
 
   def setup
     @default_title_wo_status = false
+  end
+  
+  def teardown
+    User.current = nil
   end
   
   def generate_data_with_attachment_001(num=3)
@@ -65,7 +71,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_dedicated_mails num_att_mails:1, atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_dedicated_mails num_att_mails:1, atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
 
@@ -86,7 +92,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
 
@@ -107,7 +113,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
 
@@ -128,7 +134,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
 
@@ -150,7 +156,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
 
@@ -177,7 +183,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_dedicated_mails num_att_mails:2, atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_dedicated_mails num_att_mails:2, atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
 
@@ -199,7 +205,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
 
@@ -226,7 +232,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
   
@@ -252,7 +258,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_dedicated_mails num_att_mails:3, atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_dedicated_mails num_att_mails:3, atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
   
@@ -278,7 +284,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
 
@@ -304,7 +310,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
   
@@ -326,7 +332,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_dedicated_mails num_att_mails:1, atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_dedicated_mails num_att_mails:1, atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
   
@@ -358,7 +364,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_dedicated_mails num_att_mails:2, atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_dedicated_mails num_att_mails:2, atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
   
@@ -385,7 +391,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
   
@@ -417,7 +423,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
   
@@ -449,7 +455,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
   
@@ -481,7 +487,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["dlopper@somenet.foo", "jsmith@somenet.foo"]
     end
   end
 

--- a/src/issue_mail_with_attachments/test/unit/mailer_patch_edit_status_test.rb
+++ b/src/issue_mail_with_attachments/test/unit/mailer_patch_edit_status_test.rb
@@ -65,7 +65,7 @@ class MailPatchEditStatusTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_dedicated_mails num_att_mails:1, atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_dedicated_mails num_att_mails:1, atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
 
@@ -88,7 +88,7 @@ class MailPatchEditStatusTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
 
@@ -111,7 +111,7 @@ class MailPatchEditStatusTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
 

--- a/src/issue_mail_with_attachments/test/unit/mailer_patch_edit_test.rb
+++ b/src/issue_mail_with_attachments/test/unit/mailer_patch_edit_test.rb
@@ -63,7 +63,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_dedicated_mails num_att_mails:1, atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_dedicated_mails num_att_mails:1, atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
 
@@ -84,7 +84,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
 
@@ -105,7 +105,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
 
@@ -126,7 +126,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
 
@@ -148,7 +148,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
 
@@ -175,7 +175,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_dedicated_mails num_att_mails:2, atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_dedicated_mails num_att_mails:2, atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
 
@@ -197,7 +197,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
 
@@ -224,7 +224,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
   
@@ -250,7 +250,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_dedicated_mails num_att_mails:3, atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_dedicated_mails num_att_mails:3, atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
   
@@ -276,7 +276,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
 
@@ -302,7 +302,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
   
@@ -324,7 +324,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_dedicated_mails num_att_mails:1, atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_dedicated_mails num_att_mails:1, atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
   
@@ -356,7 +356,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_dedicated_mails num_att_mails:2, atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_dedicated_mails num_att_mails:2, atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
   
@@ -383,7 +383,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
   
@@ -415,7 +415,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
   
@@ -447,7 +447,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_attach_all atts:atts, issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
   
@@ -479,7 +479,7 @@ class MailPatchEditTest < ActiveSupport::TestCase
       :plugin_issue_mail_with_attachments => plugin_settings
     }) do
       assert issue.save
-      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status
+      assert_sent_with_no_attachments issue:issue, title_wo_status:@default_title_wo_status, recipients:["jsmith@somenet.foo", "dlopper@somenet.foo"]
     end
   end
 

--- a/src/issue_mail_with_attachments/test/unit/mailer_patch_orig_issue_test.rb
+++ b/src/issue_mail_with_attachments/test/unit/mailer_patch_orig_issue_test.rb
@@ -28,7 +28,7 @@ class MailPatchAddOrigTest < ActiveSupport::TestCase
                       :subject => 'test_create', :estimated_hours => '1:30')
     with_settings :notified_events => %w(issue_added) do
       assert issue.save
-      assert_equal 1, ActionMailer::Base.deliveries.size
+      assert_equal 2, ActionMailer::Base.deliveries.size
     end
   end
 
@@ -40,7 +40,7 @@ class MailPatchAddOrigTest < ActiveSupport::TestCase
                       :subject => 'test_create', :estimated_hours => '1:30')
     with_settings :notified_events => %w(issue_added issue_updated) do
       assert issue.save
-      assert_equal 1, ActionMailer::Base.deliveries.size
+      assert_equal 2, ActionMailer::Base.deliveries.size
     end
   end
 

--- a/src/issue_mail_with_attachments/test/unit/mailer_patch_orig_journal_test.rb
+++ b/src/issue_mail_with_attachments/test/unit/mailer_patch_orig_journal_test.rb
@@ -23,7 +23,7 @@ class MailPatchEditOrigTest < ActiveSupport::TestCase
     journal = issue.init_journal(user, issue)
 
     assert journal.save
-    assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_equal 2, ActionMailer::Base.deliveries.size
   end
 
 end

--- a/src/issue_mail_with_attachments/test/unit/mailer_patch_test.rb
+++ b/src/issue_mail_with_attachments/test/unit/mailer_patch_test.rb
@@ -8,7 +8,7 @@ class MailPatchAddTest < ActiveSupport::TestCase
 def test_evaluate_attach_or_not_pairwise_comb_4
 
   CSV.foreach(File.expand_path('../../pictresult.csv', __FILE__), headers: true) do |d|
-    ps = IssueMailWithAttachments::MailerPatch::InstanceMethods::PluginSettings.new
+    ps = IssueMailWithAttachments::MailerPatch::PluginSettings.new
 #    ps = Mailer::InstanceMethods::PluginSettings.new
     ps.att_enabled = d["att_enabled"].nil? ? nil: d["att_enabled"] == 'true'? true: false
     ps.attach_all = d["attach_all"].nil? ? nil: d["att_enabled"] == 'true'? true: false
@@ -17,7 +17,7 @@ def test_evaluate_attach_or_not_pairwise_comb_4
     ps.cf_name_for_issue = d["cf_name_for_issue"]
     ps.enabled_for_issue = d["enabled_for_issue"].nil? ? nil: d["att_enabled"] == 'true'? true: false
     expected = d["result"].nil? ? nil: d["att_enabled"] == 'true'? true: false
-    actual = IssueMailWithAttachments::MailerPatch::InstanceMethods.evaluate_attach_or_not(ps)
+    actual = IssueMailWithAttachments::MailerPatch.evaluate_attach_or_not(ps)
     assert_equal expected, actual
   end
 end  


### PR DESCRIPTION
Hello, please help me.

I would like to use this plugins but I have problem with attachments file.

My environments:

Environment:
  Redmine version                4.1.1.stable
  Ruby version                   2.6.5-p114 (2019-10-01) [x86_64-linux]
  Rails version                  5.2.4.2
  Environment                    production
  Database adapter               Mysql2
  Mailer queue                   ActiveJob::QueueAdapters::AsyncAdapter
  Mailer delivery                smtp



SET configuration plugin 0.9.5
1) Enable mail attachment Send mail with attachment files.
  
    When I use this option I get:
    1) Separate email without attachments file
    2) Separate email with attachments file

    I think that is OK.


2) Attach all files to notification Attach all files to original notification mail. NOTE: Notification will be rejected by mail server when attachment size exceed server limit. If you disable this checkbox, original notification mail is sent as it is and each files will be sent by own dedicated mail.

    When I use this option I get:
    1) Separate email without attachments file
 
    I think that is wrong.  I need get only one email with attachments file.

Please help me.
Thank you Petr


